### PR TITLE
Fix escape markdown v2 reference error

### DIFF
--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1614,7 +1614,7 @@ export default async function handler(req, res) {
             console.log('🔄 Detected social media link, sending clean preview');
             
             const senderUsername = user.username || user.first_name || `User${user.id}`;
-            const escapedUsername = escapeMarkdownV2(senderUsername);
+            const escapedUsername = escapeMarkdown(senderUsername);
             
             const formattedMessage = `[Media Link](${linkData.alternativeUrl})\n\n[Original Link](${linkData.original}) sent by @${escapedUsername}`;
             


### PR DESCRIPTION
Fix `ReferenceError: escapeMarkdownV2 is not defined` by using the existing `escapeMarkdown` function.

The `ReferenceError` occurred because `escapeMarkdownV2` was called but not defined in the file. The existing `escapeMarkdown` function provides the necessary markdown escaping functionality for the `senderUsername` in the social media link preview feature, resolving the runtime error without altering the intended behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-a518364b-d008-4f6c-ab11-31da16eb1199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a518364b-d008-4f6c-ab11-31da16eb1199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

