### PR TITLE
Fix reminder parsing with mentions

### DIFF
--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1779,8 +1779,12 @@ export default async function handler(req, res) {
             return res.status(200).json({ ok: true });
         }
 
+        // FIXED: Move command detection before @all processing to prevent conflicts
+        const isCommand = text.startsWith('/') || text.startsWith('.');
+
         // ENHANCED: Check for @all mention command anywhere in the message
-        if (text.toLowerCase().includes('@all')) {
+        // BUT ONLY if it's not part of a command (like /remind)
+        if (text.toLowerCase().includes('@all') && !isCommand) {
             // Only work in the specific target group
             if (isValidMentionContext(chatId)) {
                 const mentionText = createMentionText();
@@ -1902,7 +1906,6 @@ export default async function handler(req, res) {
         }
 
         // FIXED: Updated message filtering logic
-        const isCommand = text.startsWith('/') || text.startsWith('.');
         const mathRegex = /^([\d.\s]+(?:[+\-*/][\d.\s]+)+)$/;
         const isCalculation = mathRegex.test(text);
         


### PR DESCRIPTION
Fixes reminder commands containing `@all` mentions and ensures mentions trigger only when the reminder fires.

Previously, messages containing `@all` were processed as a mention command and returned early, preventing reminder commands like `/remind "hi @all..."` from being recognized. This PR ensures commands are parsed first, and `@all` mentions within reminders are processed only when the reminder is triggered, not when it's set.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4c1e449-e3e1-4bd7-85bb-16ba5f1e3c8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4c1e449-e3e1-4bd7-85bb-16ba5f1e3c8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

