### PR TITLE
Fix reminder username display

### DIFF
--- a/api/check-alerts.js
+++ b/api/check-alerts.js
@@ -40,7 +40,7 @@ function createMentionText() {
     }
     
     return validUsernames
-        .map(username => `@${escapeUsername(username)}`)
+        .map(username => `@${username}`) // Don't escape in HTML mode
         .join(' ');
 }
 


### PR DESCRIPTION
Stop escaping usernames in `check-alerts.js` to fix broken username formatting in HTML-parsed reminder messages.

The `escapeUsername` function was designed for Markdown mode, but `check-alerts.js` sends messages using HTML parse mode. In HTML mode, backslashes used for escaping are displayed literally, causing usernames like `@anything_notslava_bot` to appear as `@anything\_notslava\_bot`.

---
<a href="https://cursor.com/background-agent?bcId=bc-49b455a1-43f2-4d70-9b2a-b3b0f3e96e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49b455a1-43f2-4d70-9b2a-b3b0f3e96e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

