### PR TITLE
Fix @all command username underscore removal

### DIFF
--- a/api/check-alerts.js
+++ b/api/check-alerts.js
@@ -9,7 +9,7 @@ const MENTION_CONFIG = {
         'Xeron888',
         'RemindMeOfThis',
         'austrianbae250',
-        'Ferno_x',
+        'ferno_x',
         'Ananthu_VB',
         'Oxshahid13',
         'unknownking7',
@@ -20,7 +20,12 @@ const MENTION_CONFIG = {
 // Helper functions for mentions (same as webhook.js)
 function escapeUsername(username) {
     if (!username || typeof username !== 'string') return '';
-    return username.replace(/[_*[\]()~`>#+=|{}.!-]/g, '\\$&');
+    // For HTML mode (used in alerts), don't escape underscores as they're valid in usernames
+    // Only escape characters that would break HTML parsing
+    return username
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
 }
 
 function createMentionText() {

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -299,7 +299,7 @@ const MENTION_CONFIG = {
         'Xeron888',
         'RemindMeOfThis',
         'austrianbae250',
-        'Ferno_x',
+        'ferno_x',
         'Ananthu_VB',
         'Oxshahid13',
         'unknownking7',


### PR DESCRIPTION
Update `@ALL` mention configuration and `escapeUsername` function to correctly preserve underscores and case in usernames.

The bot was incorrectly removing underscores and changing the case of usernames (e.g., `ferno_x` became `FernoX`) when using the `@ALL` command, leading to non-functional mentions. This was due to an incorrect entry in `MENTION_CONFIG` and an `escapeUsername` function that was over-escaping characters.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b682b57-db98-495b-818d-bbd501d2641b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b682b57-db98-495b-818d-bbd501d2641b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

